### PR TITLE
Changed 'rts to jml $01C560|!base3' 

### DIFF
--- a/powerups_files/powerup_misc_data/get_powerup/1up.asm
+++ b/powerups_files/powerup_misc_data/get_powerup/1up.asm
@@ -3,4 +3,4 @@ give_1up:
 	clc
 	adc !1594,x
 	jsl $02ACE5|!base3
-	rts
+	jml $01C560|!base3

--- a/powerups_files/powerup_misc_data/get_powerup/star.asm
+++ b/powerups_files/powerup_misc_data/get_powerup/star.asm
@@ -7,4 +7,4 @@ give_star:
 +	
 	lda #$0A
 	sta $1DF9|!base2
-	rts
+	jml $01C560|!base3


### PR DESCRIPTION
A change to the Star & 1-Up Mushroom's get_powerup files, which, supposedly, fixes a game crash when said items are collected. 