### PR TITLE
Rocket Boots fix

### DIFF
--- a/powerups_files/powerup_main_code/powerup_0A.asm
+++ b/powerups_files/powerup_main_code/powerup_0A.asm
@@ -14,10 +14,9 @@
 	ora $74
 	ora $75
 	ora $187A|!base2
+	ora $140D|!base2
 	bne .return_clear
 	
-	lda $140D|!base2
-	bne .no_reset
 	lda $1697|!base2
 	cmp !power_ram+5
 	beq .no_reset

--- a/powerups_files/powerup_main_code/powerup_0A.asm
+++ b/powerups_files/powerup_main_code/powerup_0A.asm
@@ -14,9 +14,10 @@
 	ora $74
 	ora $75
 	ora $187A|!base2
-	ora $140D|!base2
 	bne .return_clear
 	
+	lda $140D|!base2
+	bne .no_reset
 	lda $1697|!base2
 	cmp !power_ram+5
 	beq .no_reset

--- a/powerups_files/powerup_main_code/powerup_0A.asm
+++ b/powerups_files/powerup_main_code/powerup_0A.asm
@@ -6,12 +6,18 @@
 	bne .return
 	lda $77
 	and #$04
-	ora $73
+	beq +
+	lda #$00
+	sta !power_ram+5
+	bra .return_clear
++	ora $73
 	ora $74
 	ora $75
 	ora $187A|!base2
 	bne .return_clear
 	
+	lda $140D|!base2
+	bne .no_reset
 	lda $1697|!base2
 	cmp !power_ram+5
 	beq .no_reset


### PR DESCRIPTION
I just added a check which resets the stomped enemy combo mirror when on ground and made it so that you don't activate the boost after killing an enemy with a spin jump (which cancles the spin jump).